### PR TITLE
Fix value of `appleUniversalBinaryPath`

### DIFF
--- a/Sources/ArtifactBundleGen/ArtifactBundleGen.swift
+++ b/Sources/ArtifactBundleGen/ArtifactBundleGen.swift
@@ -34,7 +34,7 @@ public struct ArtifactBundleGen {
         guard fileExistChecker.isExist(path: appleUniversalBinaryPath) else { return [] }
 
         var variants: [Variant] = []
-        let supoortedArchs = try lipoRunner.chechArch(of: appleUniversalBinaryPath)
+        let supportedArchs = try lipoRunner.checkArch(of: appleUniversalBinaryPath)
 
         let appBundleUniversalBinaryFolderName = "\(name)-\(version)-macosx"
         let destinationUniversalBinaryFolderName = "\(artifactBundleFolderName)/\(appBundleUniversalBinaryFolderName)/bin"
@@ -65,7 +65,7 @@ public struct ArtifactBundleGen {
         variants.append(
             Variant(
                 path: "\(appBundleUniversalBinaryFolderName)/bin/\(name)",
-                supportedTriples: supoortedArchs.map {
+                supportedTriples: supportedArchs.map {
                     "\($0)-apple-macosx"
                 }
             )
@@ -83,18 +83,18 @@ public struct ArtifactBundleGen {
             let executablePath = "\(tripleFolderPath)/\(name)"
             guard fileExistChecker.isExist(path: executablePath) else { continue }
 
-            let artifactTripleDirectryPath = "\(artifactBundleFolderName)/\(triple)/bin"
-            try folderCreator.createFolder(name: artifactTripleDirectryPath)
+            let artifactTripleDirectoryPath = "\(artifactBundleFolderName)/\(triple)/bin"
+            try folderCreator.createFolder(name: artifactTripleDirectoryPath)
 
             let originExecutableURL = URL(fileURLWithPath: executablePath)
-            let destinationURL = URL(fileURLWithPath: "\(artifactTripleDirectryPath)/\(name)")
+            let destinationURL = URL(fileURLWithPath: "\(artifactTripleDirectoryPath)/\(name)")
 
             try fileCopy.copy(from: originExecutableURL, to: destinationURL)
             try includeResourcePaths.forEach {
                 let resourceFileURL = URL(fileURLWithPath: $0)
                 try fileCopy.copy(
                     from: resourceFileURL,
-                    to: URL(fileURLWithPath: artifactTripleDirectryPath).appendingPathComponent(resourceFileURL.lastPathComponent)
+                    to: URL(fileURLWithPath: artifactTripleDirectoryPath).appendingPathComponent(resourceFileURL.lastPathComponent)
                 )
             }
 
@@ -104,7 +104,7 @@ public struct ArtifactBundleGen {
             for bundleName in bundleNames {
                 try fileCopy.copy(
                     from: URL(fileURLWithPath: tripleFolderPath).appendingPathComponent(bundleName),
-                    to: URL(fileURLWithPath: artifactTripleDirectryPath).appendingPathComponent(bundleName)
+                    to: URL(fileURLWithPath: artifactTripleDirectoryPath).appendingPathComponent(bundleName)
                 )
             }
 

--- a/Sources/ArtifactBundleGen/ArtifactBundleGen.swift
+++ b/Sources/ArtifactBundleGen/ArtifactBundleGen.swift
@@ -23,7 +23,7 @@ public struct ArtifactBundleGen {
     }
 
     private var appleUniversalBinaryPath: String {
-        "\(appleUniversalBinaryFolderName)/xcodegen"
+        "\(appleUniversalBinaryFolderName)/\(name)"
     }
 
     private func prepareArtifactBundleFolder() throws {

--- a/Sources/ArtifactBundleGen/Error/ArtifactBundleGenError.swift
+++ b/Sources/ArtifactBundleGen/Error/ArtifactBundleGenError.swift
@@ -1,10 +1,3 @@
-//
-//  ArtifactBundleGenError.swift
-//
-//
-//  Created by JP29872 on 2022/12/07.
-//
-
 import Foundation
 
 enum ArtifactBundleGenError: LocalizedError, CustomStringConvertible {

--- a/Sources/ArtifactBundleGen/Model/ArtifactBundle.swift
+++ b/Sources/ArtifactBundleGen/Model/ArtifactBundle.swift
@@ -1,12 +1,3 @@
-//
-//  ArtifactBundle.swift
-//
-//
-//  Created by JP29872 on 2022/12/06.
-//
-
-import Foundation
-
 struct Variant: Encodable {
     var path: String
     var supportedTriples: [String]

--- a/Sources/ArtifactBundleGen/Utils/LipoRunnner.swift
+++ b/Sources/ArtifactBundleGen/Utils/LipoRunnner.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-class LipoRunnner {
-    func chechArch(of targetPath: String) throws -> [String] {
+struct LipoRunnner {
+    func checkArch(of targetPath: String) throws -> [String] {
         let task = Process()
         let pipe = Pipe()
 
@@ -19,8 +19,8 @@ class LipoRunnner {
         let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(data: outputData, encoding: .utf8)
 
-        let separaterSet = CharacterSet([" ", "\n"])
-        guard let supportedCPUs = output?.components(separatedBy: separaterSet)
+        let separatorSet = CharacterSet([" ", "\n"])
+        guard let supportedCPUs = output?.components(separatedBy: separatorSet)
             .filter({ $0 != "" })
         else {
             throw ArtifactBundleGenError.lipoEmptyResult


### PR DESCRIPTION
I noticed `appleUniversalBinaryPath` returns an invalid values by chance.
In this PR, I fixed it in 1fb9ab04d1352d0178b5a13e4ed26ce830bafccf.

And more, as  a boy scout rule, I cleaned up some code.
- Fix typo
- Remo unnecessary code header
- Make a class to a struct, because it doesn't have any mutable value.