### PR TITLE
Add "FS" command line option to the zip command

### DIFF
--- a/Sources/ArtifactBundleGen/Utils/ZipComposer.swift
+++ b/Sources/ArtifactBundleGen/Utils/ZipComposer.swift
@@ -4,7 +4,7 @@ class ZipComposer {
     func composeBundle(path bundlePath: URL) async throws {
         try await withCheckedThrowingContinuation { continuation in
             do {
-                try Process.run(URL(fileURLWithPath: "/usr/bin/zip"), arguments: ["-r", "\(bundlePath.relativePath).zip", "\(bundlePath.relativePath)"]) { _ in
+                try Process.run(URL(fileURLWithPath: "/usr/bin/zip"), arguments: ["-FSr", "\(bundlePath.relativePath).zip", "\(bundlePath.relativePath)"]) { _ in
                     continuation.resume(returning: ())
                 }
             } catch {


### PR DESCRIPTION
If the destination zip file already exists then it is updated in place if you don't use the "FS" option. This means it will keep any older outdated files it may already contain (e.g. a previous version.). Adding "FS" will remove any files from the existing zip that are not present in the generated artifact bundle directory.

To reproduce the issue just use the plugin with any version number, then immediately use it again with a different version number. You'll end up with an artifact bundle that contains both versions, but an info.json file that only references the last used version number.

This isn't a problem if you are using a CI/CD system which should have a clean clone of the repo that uses this tool, but it is an issue if you bundle artifacts manually and don't clear out previously generated bundles.